### PR TITLE
Add support for mailbox-specific limits

### DIFF
--- a/appendlimit.go
+++ b/appendlimit.go
@@ -7,4 +7,6 @@ import (
 
 const Capability = "APPENDLIMIT"
 
+const StatusAppendLimit imap.StatusItem = "APPENDLIMIT"
+
 const codeTooBig imap.StatusRespCode = "TOOBIG"

--- a/client.go
+++ b/client.go
@@ -1,0 +1,19 @@
+package appendlimit
+
+import (
+	"github.com/emersion/go-imap"
+)
+
+func MailboxStatusAppendLimit(status *imap.MailboxStatus) *uint32 {
+	val := status.Items[StatusAppendLimit]
+	if val == nil {
+		return nil
+	}
+
+	res, err := imap.ParseNumber(val)
+	if err != nil {
+		return nil
+	}
+
+	return &res
+}

--- a/server.go
+++ b/server.go
@@ -31,6 +31,16 @@ type User interface {
 	CreateMessageLimit() *uint32
 }
 
+// StatusSetAppendLimit sets limit value in MailboxStatus object,
+// nil pointer value will remove limit.
+func StatusSetAppendLimit(status *imap.MailboxStatus, value *uint32) {
+	if value != nil {
+		status.Items[StatusAppendLimit] = *value
+	} else {
+		delete(status.Items, StatusAppendLimit)
+	}
+}
+
 type extension struct{}
 
 func formatCapability(limit uint32) string {


### PR DESCRIPTION
Was not sure about type required in Items. after looking at how go-imap parses/formats responses decided to go with string, as it looks like values should be always strings. Perhaps it should be documented somewhere.

Closes #1.